### PR TITLE
fix: assignment microcode behavior

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
 		"./Cargo.toml",
 		"./vm/ignite/Cargo.toml",
 		"./src/bytecode/Cargo.toml"
-	]
+	],
+	"rust-analyzer.showUnlinkedFileNotification": false
 }

--- a/src/bytecode/src/environment.rs
+++ b/src/bytecode/src/environment.rs
@@ -244,5 +244,6 @@ mod tests {
             child_env.borrow().get(&"y".to_string()),
             Some(Value::Int(43))
         );
+        assert!(!child_env.borrow().env.contains_key(&"x".to_string()));
     }
 }

--- a/src/bytecode/src/environment.rs
+++ b/src/bytecode/src/environment.rs
@@ -1,6 +1,13 @@
-use std::{cell::RefCell, collections::HashMap, fmt::Debug, rc::Rc};
+use std::{
+    cell::RefCell,
+    collections::{hash_map::Entry, HashMap},
+    fmt::Debug,
+    rc::Rc,
+};
 
-use crate::{builtin, Symbol, Value, W};
+use anyhow::Result;
+
+use crate::{builtin, ByteCodeError, Symbol, Value, W};
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Environment {
@@ -128,9 +135,43 @@ impl Environment {
         }
     }
 
-    /// Set the value of a symbol in the frame.
+    /// Set the value of a symbol in the current environment.
+    ///
+    /// # Arguments
+    ///
+    /// * `sym` - The symbol whose value is to be set.
+    /// * `val` - The value to be set.
     pub fn set(&mut self, sym: impl Into<Symbol>, val: impl Into<Value>) {
         self.env.insert(sym.into(), val.into());
+    }
+
+    /// Update the value of a symbol in the current environment.
+    /// If the symbol is not found in the current environment, the parent environment is searched.
+    /// If the symbol is not found in the environment chain, an error is returned.
+    ///
+    /// # Arguments
+    ///
+    /// * `sym` - The symbol whose value is to be updated.
+    /// * `val` - The new value to be set.
+    ///
+    /// # Returns
+    ///
+    /// An error if the symbol is not found in the environment chain.
+    ///
+    /// # Errors
+    ///
+    /// * `ByteCodeError::UnboundedName` - If the symbol is not found in the environment chain.
+    pub fn update(&mut self, sym: impl Into<Symbol>, val: impl Into<Value>) -> Result<()> {
+        let sym = sym.into();
+
+        if let Entry::Occupied(mut entry) = self.env.entry(sym.clone()) {
+            entry.insert(val.into());
+            Ok(())
+        } else if let Some(parent) = &self.parent {
+            parent.borrow_mut().update(sym, val)
+        } else {
+            Err(ByteCodeError::UnboundedName { name: sym }.into())
+        }
     }
 }
 
@@ -160,22 +201,44 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_frame() {
+    fn test_environment() {
         let env = Environment::new_wrapped();
         env.borrow_mut().set("x", 42);
         assert_eq!(env.borrow().get(&"x".to_string()), Some(Value::Int(42)));
     }
 
     #[test]
-    fn test_frame_with_parent() {
+    fn test_set_environment() {
         let parent_env = Environment::new_wrapped();
         parent_env.borrow_mut().set("x", 42);
+
         let child_env = Environment::new_wrapped();
         child_env.borrow_mut().set_parent(parent_env);
         child_env.borrow_mut().set("y", 43);
+
         assert_eq!(
             child_env.borrow().get(&"x".to_string()),
             Some(Value::Int(42))
+        );
+        assert_eq!(
+            child_env.borrow().get(&"y".to_string()),
+            Some(Value::Int(43))
+        );
+    }
+
+    #[test]
+    fn test_update_environment() {
+        let parent_env = Environment::new_wrapped();
+        parent_env.borrow_mut().set("x", 42);
+
+        let child_env = Environment::new_wrapped();
+        child_env.borrow_mut().set_parent(parent_env);
+        child_env.borrow_mut().set("y", 43);
+        child_env.borrow_mut().update("x", 44).unwrap();
+
+        assert_eq!(
+            child_env.borrow().get(&"x".to_string()),
+            Some(Value::Int(44))
         );
         assert_eq!(
             child_env.borrow().get(&"y".to_string()),

--- a/src/bytecode/src/error.rs
+++ b/src/bytecode/src/error.rs
@@ -8,6 +8,6 @@ pub enum ByteCodeError {
     #[error("Bad type, expected {expected}, found {found}")]
     BadType { expected: String, found: String },
 
-    #[error("Unbounded name {name}")]
+    #[error("Unbounded name: {name}")]
     UnboundedName { name: String },
 }

--- a/src/bytecode/src/error.rs
+++ b/src/bytecode/src/error.rs
@@ -7,4 +7,7 @@ pub enum ByteCodeError {
 
     #[error("Bad type, expected {expected}, found {found}")]
     BadType { expected: String, found: String },
+
+    #[error("Unbounded name {name}")]
+    UnboundedName { name: String },
 }

--- a/vm/ignite/src/error.rs
+++ b/vm/ignite/src/error.rs
@@ -2,7 +2,7 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum VmError {
-    #[error("io error: {0}")]
+    #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
     #[error("File does not exist: {0}")]
@@ -11,36 +11,33 @@ pub enum VmError {
     #[error("File is not a .o2 file: {0}")]
     NotO2File(String),
 
-    #[error("symbol not found: {0}")]
-    SymbolNotFound(String),
+    #[error("Unbounded name: {0}")]
+    UnboundedName(String),
 
-    #[error("operand stack underflow")]
+    #[error("Operand stack underflow")]
     OperandStackUnderflow,
 
-    #[error("runtime stack underflow")]
+    #[error("Runtime stack underflow")]
     RuntimeStackUnderflow,
 
-    #[error("pc out of bounds: {0}")]
+    #[error("PC out of bounds: {0}")]
     PcOutOfBounds(usize),
 
-    #[error("bad type: expected {expected}, found {found}")]
+    #[error("Bad type: expected {expected}, found {found}")]
     BadType { expected: String, found: String },
 
-    #[error("bad argument: {0}")]
+    #[error("Illegal argument: {0}")]
     IllegalArgument(String),
 
-    #[error("arity and params mismatch: arity {arity}, found {params} params")]
+    #[error("Arity and params mismatch: arity {arity}, found {params} params")]
     ArityParamsMismatch { arity: usize, params: usize },
 
     #[error("Insufficient arguments: expected {expected}, got {got}")]
     InsufficientArguments { expected: usize, got: usize },
 
-    #[error("unknown builtin: {sym}")]
+    #[error("Unknown builtin: {sym}")]
     UnknownBuiltin { sym: String },
 
-    #[error("unimplemented")]
+    #[error("Unimplemented")]
     Unimplemented,
-
-    #[error("generic error: {0}")]
-    Generic(String),
 }

--- a/vm/ignite/src/micro_code/assign.rs
+++ b/vm/ignite/src/micro_code/assign.rs
@@ -14,17 +14,20 @@ use crate::{Runtime, VmError};
 /// # Errors
 ///
 /// If the stack is empty.
+/// If the symbol is not found in the environment chain.
 pub fn assign(rt: &mut Runtime, sym: Symbol) -> Result<()> {
     let val = rt
         .operand_stack
         .pop()
         .ok_or(VmError::OperandStackUnderflow)?;
-    rt.env.borrow_mut().set(sym, val);
+    rt.env.borrow_mut().update(sym, val)?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::rc::Rc;
+
     use bytecode::{Environment, Value};
 
     use super::*;
@@ -32,22 +35,48 @@ mod tests {
     #[test]
     fn test_assign() {
         let mut rt = Runtime::new(vec![]);
+        rt.env.borrow_mut().set("x", Value::Unitialized);
         rt.operand_stack.push(Value::Int(42));
+
         assign(&mut rt, "x".to_string()).unwrap();
+
+        assert_ne!(
+            rt.env.borrow().get(&"x".to_string()),
+            Some(Value::Unitialized)
+        );
         assert_eq!(rt.env.borrow().get(&"x".to_string()), Some(Value::Int(42)));
     }
 
     #[test]
     fn test_assign_with_parent() {
-        let parent = Environment::new_wrapped();
-        parent.borrow_mut().set("x", 42);
         let mut rt = Runtime::new(vec![]);
-        let frame = Environment::new_wrapped();
-        frame.borrow_mut().set_parent(parent);
-        rt.env = frame;
-        rt.operand_stack.push(Value::Int(43));
+
+        let parent_env = Environment::new_wrapped();
+        parent_env.borrow_mut().set("x", 42);
+
+        let child_env = Environment::new_wrapped();
+        child_env.borrow_mut().set_parent(Rc::clone(&parent_env));
+        child_env.borrow_mut().set("y", Value::Unitialized);
+
+        rt.env = Rc::clone(&child_env);
+        rt.operand_stack.push(Value::Int(123));
+        assign(&mut rt, "x".to_string()).unwrap();
+
+        assert_eq!(
+            parent_env.borrow().get(&"x".to_string()),
+            Some(Value::Int(123))
+        );
+        // The child environment should not be updated.
+        assert!(!child_env.borrow().env.contains_key(&"x".to_string()));
+
+        rt.operand_stack.push(Value::Int(789));
         assign(&mut rt, "y".to_string()).unwrap();
-        assert_eq!(rt.env.borrow().get(&"x".to_string()), Some(Value::Int(42)));
-        assert_eq!(rt.env.borrow().get(&"y".to_string()), Some(Value::Int(43)));
+
+        assert!(parent_env.borrow().get(&"y".to_string()).is_none());
+        assert_eq!(
+            child_env.borrow().get(&"y".to_string()),
+            Some(Value::Int(789))
+        );
+        assert_eq!(rt.env.borrow().get(&"y".to_string()), Some(Value::Int(789)));
     }
 }

--- a/vm/ignite/src/micro_code/ld.rs
+++ b/vm/ignite/src/micro_code/ld.rs
@@ -19,7 +19,7 @@ pub fn ld(rt: &mut Runtime, sym: Symbol) -> Result<()> {
         .env
         .borrow()
         .get(&sym)
-        .ok_or_else(|| VmError::SymbolNotFound(sym.clone()))?;
+        .ok_or_else(|| VmError::UnboundedName(sym.clone()))?;
     rt.operand_stack.push(val);
     Ok(())
 }

--- a/vm/ignite/src/runtime.rs
+++ b/vm/ignite/src/runtime.rs
@@ -228,7 +228,11 @@ mod tests {
             ByteCode::assign("x"),
             ByteCode::DONE,
         ];
+
         let rt = Runtime::new(instrs);
+        rt.env.borrow_mut().set("x", Value::Unitialized);
+        rt.env.borrow_mut().set("y", Value::Unitialized);
+
         let rt = run(rt).unwrap();
         assert_eq!(rt.env.borrow().get(&"x".to_string()), Some(Value::Int(44)));
         assert_eq!(rt.env.borrow().get(&"y".to_string()), Some(Value::Int(43)));


### PR DESCRIPTION
### Description
- The `assign` microcode did not exhibit correction behavior - namely, it should only update values of the existing keys in the chain of environment rather than setting them.
- Initializing keys in environments is done by `extend_environment`, which is called by `enter_scope` or `call` microcode

### Expected
- Assign microcode updates the value of key/symbol in the nearest scope that contains an entry of the specified key/symbol

### Actual
- Assign microcode inserts the key value pair in the current scope

This PR corrects this behavior

Addresses https://github.com/crabscript/rustscript/pull/27#discussion_r1558106372