### PR TITLE
style: remove W newtype pattern

### DIFF
--- a/src/bytecode/src/builtin/conv/atoi.rs
+++ b/src/bytecode/src/builtin/conv/atoi.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const ATOI_SYM: &str = "atoi";
 
@@ -12,7 +12,7 @@ pub fn atoi(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: ATOI_SYM.into(),
         prms: vec!["s".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/conv/float_to_int.rs
+++ b/src/bytecode/src/builtin/conv/float_to_int.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const FLOAT_TO_INT_SYM: &str = "float_to_int";
 
@@ -12,7 +12,7 @@ pub fn float_to_int(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: FLOAT_TO_INT_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/conv/int_to_float.rs
+++ b/src/bytecode/src/builtin/conv/int_to_float.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const INT_TO_FLOAT_SYM: &str = "int_to_float";
 
@@ -12,7 +12,7 @@ pub fn int_to_float(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: INT_TO_FLOAT_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/conv/itoa.rs
+++ b/src/bytecode/src/builtin/conv/itoa.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const ITOA_SYM: &str = "itoa";
 
@@ -12,7 +12,7 @@ pub fn itoa(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: ITOA_SYM.into(),
         prms: vec!["i".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/math/abs.rs
+++ b/src/bytecode/src/builtin/math/abs.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{type_of, ByteCodeError, Environment, FnType, Value, W};
+use crate::{type_of, ByteCodeError, Environment, FnType, Value};
 
 pub const ABS_SYM: &str = "abs";
 
@@ -12,7 +12,7 @@ pub fn abs(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: ABS_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/math/cos.rs
+++ b/src/bytecode/src/builtin/math/cos.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const COS_SYM: &str = "cos";
 
@@ -12,7 +12,7 @@ pub fn cos(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: COS_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/math/log.rs
+++ b/src/bytecode/src/builtin/math/log.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const LOG_SYM: &str = "log";
 
@@ -12,7 +12,7 @@ pub fn log(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: LOG_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/math/max.rs
+++ b/src/bytecode/src/builtin/math/max.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const MAX_SYM: &str = "max";
 
@@ -12,7 +12,7 @@ pub fn max(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: MAX_SYM.into(),
         prms: vec!["v1".into(), "v2".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/math/min.rs
+++ b/src/bytecode/src/builtin/math/min.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{type_of, ByteCodeError, Environment, FnType, Value, W};
+use crate::{type_of, ByteCodeError, Environment, FnType, Value};
 
 pub const MIN_SYM: &str = "min";
 
@@ -12,7 +12,7 @@ pub fn min(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: MIN_SYM.into(),
         prms: vec!["v1".into(), "v2".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/math/pow.rs
+++ b/src/bytecode/src/builtin/math/pow.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const POW_SYM: &str = "pow";
 
@@ -12,7 +12,7 @@ pub fn pow(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: POW_SYM.into(),
         prms: vec!["base".into(), "exp".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/math/sin.rs
+++ b/src/bytecode/src/builtin/math/sin.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const SIN_SYM: &str = "sin";
 
@@ -12,7 +12,7 @@ pub fn sin(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: SIN_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/math/sqrt.rs
+++ b/src/bytecode/src/builtin/math/sqrt.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const SQRT_SYM: &str = "sqrt";
 
@@ -12,7 +12,7 @@ pub fn sqrt(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: SQRT_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/math/tan.rs
+++ b/src/bytecode/src/builtin/math/tan.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const TAN_SYM: &str = "tan";
 
@@ -12,7 +12,7 @@ pub fn tan(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: TAN_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/stdin/read_line.rs
+++ b/src/bytecode/src/builtin/stdin/read_line.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const READ_LINE_SYM: &str = "read_line";
 
@@ -12,7 +12,7 @@ pub fn read_line(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: READ_LINE_SYM.into(),
         prms: vec![],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/stdout/print.rs
+++ b/src/bytecode/src/builtin/stdout/print.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, rc::Rc};
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const PRINT_SYM: &str = "print";
 
@@ -10,7 +10,7 @@ pub fn print(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: PRINT_SYM.into(),
         prms: vec!["s".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/stdout/println.rs
+++ b/src/bytecode/src/builtin/stdout/println.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, rc::Rc};
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const PRINTLN_SYM: &str = "println";
 
@@ -10,7 +10,7 @@ pub fn println(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: PRINTLN_SYM.into(),
         prms: vec!["s".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/builtin/string/len.rs
+++ b/src/bytecode/src/builtin/string/len.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value, W};
+use crate::{Environment, FnType, Value};
 
 pub const STRING_LEN_SYM: &str = "string_len";
 
@@ -12,7 +12,7 @@ pub fn string_len(global_env: Rc<RefCell<Environment>>) -> Value {
         sym: STRING_LEN_SYM.into(),
         prms: vec!["s".into()],
         addr: 0,
-        env: W(global_env),
+        env: global_env,
     }
 }
 

--- a/src/bytecode/src/environment.rs
+++ b/src/bytecode/src/environment.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::Result;
 
-use crate::{builtin, ByteCodeError, Symbol, Value, W};
+use crate::{builtin, ByteCodeError, Symbol, Value};
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Environment {
@@ -172,27 +172,6 @@ impl Environment {
         } else {
             Err(ByteCodeError::UnboundedName { name: sym }.into())
         }
-    }
-}
-
-/// Implement Clone trait to satisfy the requirements of Value enum.
-impl Clone for W<Rc<RefCell<Environment>>> {
-    fn clone(&self) -> Self {
-        W(self.0.clone())
-    }
-}
-
-/// Implement PartialEq trait to satisfy the requirements of Value enum.
-impl PartialEq for W<Rc<RefCell<Environment>>> {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-
-/// Implement Debug trait to satisfy the requirements of Value enum.
-impl Debug for W<Rc<RefCell<Environment>>> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.borrow().fmt(f)
     }
 }
 

--- a/src/bytecode/src/value.rs
+++ b/src/bytecode/src/value.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, rc::Rc};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ByteCodeError, Environment, Symbol, W};
+use crate::{ByteCodeError, Environment, Symbol};
 
 /// The values that can be stored on the operant stack.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -19,7 +19,7 @@ pub enum Value {
         sym: Symbol,
         prms: Vec<Symbol>,
         addr: usize,
-        env: W<Rc<RefCell<Environment>>>,
+        env: Rc<RefCell<Environment>>,
     },
 }
 

--- a/vm/ignite/src/micro_code/call.rs
+++ b/vm/ignite/src/micro_code/call.rs
@@ -71,7 +71,7 @@ pub fn call(rt: &mut Runtime, arity: usize) -> Result<()> {
 
     let frame = StackFrame {
         frame_type: FrameType::CallFrame,
-        env: Rc::clone(&env.0),
+        env: Rc::clone(&env),
         address: Some(rt.pc),
     };
 
@@ -85,7 +85,7 @@ pub fn call(rt: &mut Runtime, arity: usize) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytecode::{ByteCode, Environment, FnType, W};
+    use bytecode::{ByteCode, Environment, FnType};
 
     #[test]
     fn test_call() {
@@ -99,7 +99,7 @@ mod tests {
             sym: "Closure".to_string(),
             prms: vec![],
             addr: 123,
-            env: W(Environment::new_wrapped()),
+            env: Environment::new_wrapped(),
         });
 
         let result = call(&mut rt, 0);

--- a/vm/ignite/src/micro_code/ldf.rs
+++ b/vm/ignite/src/micro_code/ldf.rs
@@ -1,7 +1,7 @@
 use std::rc::Rc;
 
 use anyhow::Result;
-use bytecode::{FnType, Symbol, Value, W};
+use bytecode::{FnType, Symbol, Value};
 
 use crate::Runtime;
 
@@ -24,7 +24,7 @@ pub fn ldf(rt: &mut Runtime, addr: usize, prms: Vec<Symbol>) -> Result<()> {
         sym: "Closure".to_string(),
         prms,
         addr,
-        env: W(Rc::clone(&rt.env)),
+        env: Rc::clone(&rt.env),
     };
 
     rt.operand_stack.push(closure);
@@ -48,7 +48,7 @@ mod tests {
                 sym: "Closure".to_string(),
                 prms: vec!["y".to_string()],
                 addr: 0,
-                env: W(Rc::clone(&rt.env)),
+                env: Rc::clone(&rt.env),
             }
         )
     }


### PR DESCRIPTION
### Description
- Previously, I needed [newtype pattern](https://rust-unofficial.github.io/patterns/patterns/behavioural/newtype.html) to implement Traits for `Rc<Refcell<Env>>` so that `Value::Closure` satisfies `Serialize` and `Deserialize` traits. But with `#[serde(skip_serializing, skip_deserializing)]`, this is no longer necessary
- This PR reverts usage of newtype pattern