### PR TITLE
feat: mark and sweep environment

### DIFF
--- a/example/garbage-collection-01.rst
+++ b/example/garbage-collection-01.rst
@@ -1,0 +1,4 @@
+{
+  fn garbage() {}
+}
+// garbage is out of scope and not reachable, so the environment should be removed

--- a/example/garbage-collection-02.rst
+++ b/example/garbage-collection-02.rst
@@ -1,0 +1,9 @@
+fn higher_order(x) {
+  return y => x + y;
+}
+
+const add10 = higher_order(10);
+
+const result = add10(20);
+
+println(result); // 30

--- a/src/bytecode/src/builtin/conv/atoi.rs
+++ b/src/bytecode/src/builtin/conv/atoi.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const ATOI_SYM: &str = "atoi";
 
-pub fn atoi(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn atoi() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: ATOI_SYM.into(),
         prms: vec!["s".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/conv/float_to_int.rs
+++ b/src/bytecode/src/builtin/conv/float_to_int.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const FLOAT_TO_INT_SYM: &str = "float_to_int";
 
-pub fn float_to_int(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn float_to_int() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: FLOAT_TO_INT_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/conv/int_to_float.rs
+++ b/src/bytecode/src/builtin/conv/int_to_float.rs
@@ -1,18 +1,17 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value};
-
+use crate::{FnType, Value, W};
 pub const INT_TO_FLOAT_SYM: &str = "int_to_float";
 
-pub fn int_to_float(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn int_to_float() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: INT_TO_FLOAT_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/conv/itoa.rs
+++ b/src/bytecode/src/builtin/conv/itoa.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const ITOA_SYM: &str = "itoa";
 
-pub fn itoa(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn itoa() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: ITOA_SYM.into(),
         prms: vec!["i".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/math/abs.rs
+++ b/src/bytecode/src/builtin/math/abs.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{type_of, ByteCodeError, Environment, FnType, Value};
+use crate::{type_of, ByteCodeError, FnType, Value, W};
 
 pub const ABS_SYM: &str = "abs";
 
-pub fn abs(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn abs() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: ABS_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/math/cos.rs
+++ b/src/bytecode/src/builtin/math/cos.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const COS_SYM: &str = "cos";
 
-pub fn cos(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn cos() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: COS_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/math/log.rs
+++ b/src/bytecode/src/builtin/math/log.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const LOG_SYM: &str = "log";
 
-pub fn log(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn log() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: LOG_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/math/max.rs
+++ b/src/bytecode/src/builtin/math/max.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const MAX_SYM: &str = "max";
 
-pub fn max(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn max() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: MAX_SYM.into(),
         prms: vec!["v1".into(), "v2".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/math/min.rs
+++ b/src/bytecode/src/builtin/math/min.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{type_of, ByteCodeError, Environment, FnType, Value};
+use crate::{type_of, ByteCodeError, FnType, Value, W};
 
 pub const MIN_SYM: &str = "min";
 
-pub fn min(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn min() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: MIN_SYM.into(),
         prms: vec!["v1".into(), "v2".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/math/pow.rs
+++ b/src/bytecode/src/builtin/math/pow.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const POW_SYM: &str = "pow";
 
-pub fn pow(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn pow() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: POW_SYM.into(),
         prms: vec!["base".into(), "exp".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/math/sin.rs
+++ b/src/bytecode/src/builtin/math/sin.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const SIN_SYM: &str = "sin";
 
-pub fn sin(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn sin() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: SIN_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/math/sqrt.rs
+++ b/src/bytecode/src/builtin/math/sqrt.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const SQRT_SYM: &str = "sqrt";
 
-pub fn sqrt(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn sqrt() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: SQRT_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/math/tan.rs
+++ b/src/bytecode/src/builtin/math/tan.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const TAN_SYM: &str = "tan";
 
-pub fn tan(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn tan() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: TAN_SYM.into(),
         prms: vec!["x".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/semaphore/sem_create.rs
+++ b/src/bytecode/src/builtin/semaphore/sem_create.rs
@@ -1,16 +1,16 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
-use crate::{Environment, FnType, Semaphore, Value};
+use crate::{FnType, Semaphore, Value, W};
 
 pub const SEM_CREATE_SYM: &str = "sem_create";
 
-pub fn sem_create(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn sem_create() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: SEM_CREATE_SYM.into(),
         prms: vec![],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/semaphore/sem_set.rs
+++ b/src/bytecode/src/builtin/semaphore/sem_set.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Semaphore, Value};
+use crate::{FnType, Semaphore, Value, W};
 
 pub const SEM_SET_SYM: &str = "sem_set";
 
-pub fn sem_set(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn sem_set() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: SEM_SET_SYM.into(),
         prms: vec![],
         addr: 2,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/stdin/read_line.rs
+++ b/src/bytecode/src/builtin/stdin/read_line.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const READ_LINE_SYM: &str = "read_line";
 
-pub fn read_line(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn read_line() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: READ_LINE_SYM.into(),
         prms: vec![],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/stdout/print.rs
+++ b/src/bytecode/src/builtin/stdout/print.rs
@@ -1,16 +1,16 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const PRINT_SYM: &str = "print";
 
-pub fn print(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn print() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: PRINT_SYM.into(),
         prms: vec!["s".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/stdout/println.rs
+++ b/src/bytecode/src/builtin/stdout/println.rs
@@ -1,16 +1,16 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const PRINTLN_SYM: &str = "println";
 
-pub fn println(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn println() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: PRINTLN_SYM.into(),
         prms: vec!["s".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/builtin/string/len.rs
+++ b/src/bytecode/src/builtin/string/len.rs
@@ -1,18 +1,18 @@
-use std::{cell::RefCell, rc::Rc};
+use std::rc::Weak;
 
 use anyhow::Result;
 
-use crate::{Environment, FnType, Value};
+use crate::{FnType, Value, W};
 
 pub const STRING_LEN_SYM: &str = "string_len";
 
-pub fn string_len(global_env: Rc<RefCell<Environment>>) -> Value {
+pub fn string_len() -> Value {
     Value::Closure {
         fn_type: FnType::Builtin,
         sym: STRING_LEN_SYM.into(),
         prms: vec!["s".into()],
         addr: 0,
-        env: global_env,
+        env: W(Weak::new()),
     }
 }
 

--- a/src/bytecode/src/environment/env.rs
+++ b/src/bytecode/src/environment/env.rs
@@ -195,7 +195,7 @@ impl Environment {
 
 pub fn weak_clone(env: &Rc<RefCell<Environment>>) -> Weak<RefCell<Environment>> {
     let env = Rc::clone(env);
-    Rc::downgrade(&env)
+    weak_clone(&env)
 }
 
 #[cfg(test)]

--- a/src/bytecode/src/environment/env.rs
+++ b/src/bytecode/src/environment/env.rs
@@ -195,7 +195,7 @@ impl Environment {
 
 pub fn weak_clone(env: &Rc<RefCell<Environment>>) -> Weak<RefCell<Environment>> {
     let env = Rc::clone(env);
-    weak_clone(&env)
+    Rc::downgrade(&env)
 }
 
 #[cfg(test)]

--- a/src/bytecode/src/environment/mod.rs
+++ b/src/bytecode/src/environment/mod.rs
@@ -1,0 +1,7 @@
+pub use env::*;
+pub use strong::*;
+pub use weak::*;
+
+mod env;
+mod strong;
+mod weak;

--- a/src/bytecode/src/environment/strong.rs
+++ b/src/bytecode/src/environment/strong.rs
@@ -1,0 +1,23 @@
+use std::{
+    cell::RefCell,
+    hash::{Hash, Hasher},
+    rc::Rc,
+};
+
+use crate::{Environment, W};
+
+pub type EnvStrong = W<Rc<RefCell<Environment>>>;
+
+impl PartialEq for EnvStrong {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for EnvStrong {}
+
+impl Hash for EnvStrong {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        Rc::as_ptr(&self.0).hash(state)
+    }
+}

--- a/src/bytecode/src/environment/weak.rs
+++ b/src/bytecode/src/environment/weak.rs
@@ -20,8 +20,8 @@ impl Debug for EnvWeak {
         let this = self.0.upgrade();
 
         match this {
-            Some(this) => write!(f, "{:?}", this),
-            None => write!(f, "Weak::None"),
+            Some(this) => write!(f, "{:?}", this.borrow()),
+            None => write!(f, "None"),
         }
     }
 }

--- a/src/bytecode/src/environment/weak.rs
+++ b/src/bytecode/src/environment/weak.rs
@@ -1,0 +1,58 @@
+use std::{
+    cell::RefCell,
+    fmt::Debug,
+    hash::{Hash, Hasher},
+    rc::{Rc, Weak},
+};
+
+use crate::{Environment, W};
+
+pub type EnvWeak = W<Weak<RefCell<Environment>>>;
+
+impl Clone for EnvWeak {
+    fn clone(&self) -> Self {
+        W(self.0.clone())
+    }
+}
+
+impl Debug for EnvWeak {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let this = self.0.upgrade();
+
+        match this {
+            Some(this) => write!(f, "{:?}", this),
+            None => write!(f, "Weak::None"),
+        }
+    }
+}
+
+impl Default for EnvWeak {
+    fn default() -> Self {
+        W(Weak::new())
+    }
+}
+
+impl PartialEq for EnvWeak {
+    fn eq(&self, other: &Self) -> bool {
+        let this = self.0.upgrade();
+        let other = other.0.upgrade();
+
+        match (this, other) {
+            (Some(this), Some(other)) => Rc::ptr_eq(&this, &other),
+            _ => false,
+        }
+    }
+}
+
+impl Eq for EnvWeak {}
+
+impl Hash for EnvWeak {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let this = self.0.upgrade();
+
+        match this {
+            Some(this) => Rc::as_ptr(&this).hash(state),
+            None => state.write_usize(0),
+        }
+    }
+}

--- a/src/bytecode/src/error.rs
+++ b/src/bytecode/src/error.rs
@@ -10,4 +10,7 @@ pub enum ByteCodeError {
 
     #[error("Unbounded name: {name}")]
     UnboundedName { name: String },
+
+    #[error("Environment access after drop")]
+    EnvironmentDroppedError,
 }

--- a/src/bytecode/src/stack_frame.rs
+++ b/src/bytecode/src/stack_frame.rs
@@ -1,8 +1,6 @@
-use std::{cell::RefCell, rc::Rc};
-
 use serde::{Deserialize, Serialize};
 
-use crate::Environment;
+use crate::EnvWeak;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum FrameType {
@@ -14,11 +12,11 @@ pub enum FrameType {
 pub struct StackFrame {
     pub frame_type: FrameType,
     pub address: Option<usize>,
-    pub env: Rc<RefCell<Environment>>,
+    pub env: EnvWeak,
 }
 
 impl StackFrame {
-    pub fn new(frame_type: FrameType, env: Rc<RefCell<Environment>>) -> Self {
+    pub fn new(frame_type: FrameType, env: EnvWeak) -> Self {
         StackFrame {
             frame_type,
             address: None,
@@ -26,11 +24,7 @@ impl StackFrame {
         }
     }
 
-    pub fn new_with_address(
-        frame_type: FrameType,
-        env: Rc<RefCell<Environment>>,
-        address: usize,
-    ) -> Self {
+    pub fn new_with_address(frame_type: FrameType, env: EnvWeak, address: usize) -> Self {
         StackFrame {
             frame_type,
             address: Some(address),

--- a/src/bytecode/src/value.rs
+++ b/src/bytecode/src/value.rs
@@ -1,11 +1,11 @@
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 
 use serde::{Deserialize, Serialize};
 
 use crate::{ByteCodeError, EnvWeak, Semaphore, Symbol};
 
 /// The values that can be stored on the operant stack.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub enum Value {
     Unitialized,
     Unit,
@@ -56,6 +56,32 @@ impl Display for Value {
             Value::Float(f) => f.to_string(),
             Value::Semaphore(_) => "semaphore".to_string(),
             Value::Closure { .. } => "closure".to_string(),
+        };
+
+        write!(f, "{}", res)
+    }
+}
+
+impl Debug for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let res = match self {
+            Value::Unitialized => "uninitialized".to_string(),
+            Value::Unit => "()".to_string(),
+            Value::String(s) => s.to_string(),
+            Value::Bool(b) => b.to_string(),
+            Value::Int(i) => i.to_string(),
+            Value::Float(f) => f.to_string(),
+            Value::Semaphore(_) => "semaphore".to_string(),
+            Value::Closure {
+                sym,
+                fn_type,
+                prms,
+                addr,
+                ..
+            } => format!(
+                "Closure {{ sym: {}, fn_type: {:?}, prms: {:?}, addr: {} }}",
+                sym, fn_type, prms, addr
+            ),
         };
 
         write!(f, "{}", res)

--- a/src/bytecode/src/value.rs
+++ b/src/bytecode/src/value.rs
@@ -1,8 +1,8 @@
-use std::{cell::RefCell, fmt::Display, rc::Rc};
+use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ByteCodeError, Environment, Semaphore, Symbol};
+use crate::{ByteCodeError, EnvWeak, Semaphore, Symbol};
 
 /// The values that can be stored on the operant stack.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -21,7 +21,7 @@ pub enum Value {
         sym: Symbol,
         prms: Vec<Symbol>,
         addr: usize,
-        env: Rc<RefCell<Environment>>,
+        env: EnvWeak,
     },
 }
 

--- a/vm/ignite/src/error.rs
+++ b/vm/ignite/src/error.rs
@@ -44,6 +44,9 @@ pub enum VmError {
     #[error("Insufficient arguments: expected {expected}, got {got}")]
     InsufficientArguments { expected: usize, got: usize },
 
+    #[error("Environment access after drop")]
+    EnvironmentDroppedError,
+
     #[error("Unknown builtin: {sym}")]
     UnknownBuiltin { sym: String },
 }

--- a/vm/ignite/src/main.rs
+++ b/vm/ignite/src/main.rs
@@ -28,14 +28,19 @@ struct Args {
     #[arg(long, short)]
     repl: bool,
 
-    /// Set custom time quantum for the VM.
-    /// Default is 1000.
+    /// Set custom time quantum for the VM in milliseconds.
+    /// Default is 100ms.
     #[arg(short, long)]
-    quantum: Option<usize>,
+    quantum: Option<u64>,
+
+    /// Set custom garbage collection interval for the VM in milliseconds.
+    /// Default is 1000ms.
+    #[arg(short, long)]
+    gc_interval: Option<u64>,
 
     /// Turn debugging information on
-    #[arg(short, long, action = clap::ArgAction::Count)]
-    debug: u8,
+    #[arg(short, long)]
+    debug: bool,
 
     /// If present, does not type check in REPL. Ignored if only running bytecode.
     #[arg(short)]
@@ -73,10 +78,14 @@ fn main() -> Result<()> {
     let mut rt = Runtime::new(bytecode_vec);
 
     if let Some(quantum) = args.quantum {
-        rt.set_time_quantum(Duration::from_millis(quantum as u64));
+        rt.set_time_quantum(Duration::from_millis(quantum));
     }
 
-    if args.debug > 0 {
+    if let Some(gc_interval) = args.gc_interval {
+        rt.set_gc_interval(Duration::from_millis(gc_interval));
+    }
+
+    if args.debug {
         rt.set_debug_mode();
     }
 

--- a/vm/ignite/src/micro_code/assign.rs
+++ b/vm/ignite/src/micro_code/assign.rs
@@ -21,7 +21,13 @@ pub fn assign(mut rt: Runtime, sym: Symbol) -> Result<Runtime> {
         .operand_stack
         .pop()
         .ok_or(VmError::OperandStackUnderflow)?;
-    rt.current_thread.env.borrow_mut().update(sym, val)?;
+    rt.current_thread
+        .env
+        .upgrade()
+        .ok_or(VmError::EnvironmentDroppedError)?
+        .borrow_mut()
+        .update(sym, val)?;
+
     Ok(rt)
 }
 
@@ -34,10 +40,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_assign() {
+    fn test_assign() -> Result<()> {
         let mut rt = Runtime::new(vec![]);
         rt.current_thread
             .env
+            .upgrade()
+            .unwrap()
             .borrow_mut()
             .set("x", Value::Unitialized);
         rt.current_thread.operand_stack.push(Value::Int(42));
@@ -45,48 +53,63 @@ mod tests {
         rt = assign(rt, "x".to_string()).unwrap();
 
         assert_ne!(
-            rt.current_thread.env.borrow().get(&"x".to_string()),
-            Some(Value::Unitialized)
+            rt.current_thread
+                .env
+                .upgrade()
+                .unwrap()
+                .borrow()
+                .get(&"x".to_string())?,
+            Value::Unitialized
         );
         assert_eq!(
-            rt.current_thread.env.borrow().get(&"x".to_string()),
-            Some(Value::Int(42))
+            rt.current_thread
+                .env
+                .upgrade()
+                .unwrap()
+                .borrow()
+                .get(&"x".to_string())?,
+            Value::Int(42)
         );
+
+        Ok(())
     }
 
     #[test]
-    fn test_assign_with_parent() {
+    fn test_assign_with_parent() -> Result<()> {
         let mut rt = Runtime::new(vec![]);
 
         let parent_env = Environment::new_wrapped();
+        let parent_weak = Rc::downgrade(&parent_env);
         parent_env.borrow_mut().set("x", 42);
 
         let child_env = Environment::new_wrapped();
-        child_env.borrow_mut().set_parent(Rc::clone(&parent_env));
+        child_env.borrow_mut().set_parent(parent_weak);
         child_env.borrow_mut().set("y", Value::Unitialized);
+        let child_weak = Rc::downgrade(&child_env);
 
-        rt.current_thread.env = Rc::clone(&child_env);
+        rt.current_thread.env = child_weak;
         rt.current_thread.operand_stack.push(Value::Int(123));
         rt = assign(rt, "x".to_string()).unwrap();
 
-        assert_eq!(
-            parent_env.borrow().get(&"x".to_string()),
-            Some(Value::Int(123))
-        );
+        assert_eq!(parent_env.borrow().get(&"x".to_string())?, Value::Int(123));
         // The child environment should not be updated.
         assert!(!child_env.borrow().env.contains_key(&"x".to_string()));
 
         rt.current_thread.operand_stack.push(Value::Int(789));
         rt = assign(rt, "y".to_string()).unwrap();
 
-        assert!(parent_env.borrow().get(&"y".to_string()).is_none());
+        assert!(parent_env.borrow().get(&"y".to_string()).is_err());
+        assert_eq!(child_env.borrow().get(&"y".to_string())?, Value::Int(789));
         assert_eq!(
-            child_env.borrow().get(&"y".to_string()),
-            Some(Value::Int(789))
+            rt.current_thread
+                .env
+                .upgrade()
+                .unwrap()
+                .borrow()
+                .get(&"y".to_string())?,
+            Value::Int(789)
         );
-        assert_eq!(
-            rt.current_thread.env.borrow().get(&"y".to_string()),
-            Some(Value::Int(789))
-        );
+
+        Ok(())
     }
 }

--- a/vm/ignite/src/micro_code/assign.rs
+++ b/vm/ignite/src/micro_code/assign.rs
@@ -33,9 +33,7 @@ pub fn assign(mut rt: Runtime, sym: Symbol) -> Result<Runtime> {
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
-
-    use bytecode::{Environment, Value};
+    use bytecode::{weak_clone, Environment, Value};
 
     use super::*;
 
@@ -79,13 +77,13 @@ mod tests {
         let mut rt = Runtime::new(vec![]);
 
         let parent_env = Environment::new_wrapped();
-        let parent_weak = Rc::downgrade(&parent_env);
+        let parent_weak = weak_clone(&parent_env);
         parent_env.borrow_mut().set("x", 42);
 
         let child_env = Environment::new_wrapped();
         child_env.borrow_mut().set_parent(parent_weak);
         child_env.borrow_mut().set("y", Value::Unitialized);
-        let child_weak = Rc::downgrade(&child_env);
+        let child_weak = weak_clone(&child_env);
 
         rt.current_thread.env = child_weak;
         rt.current_thread.operand_stack.push(Value::Int(123));

--- a/vm/ignite/src/micro_code/call.rs
+++ b/vm/ignite/src/micro_code/call.rs
@@ -1,9 +1,7 @@
-use std::rc::Rc;
-
 use anyhow::Result;
 use bytecode::{type_of, FnType, FrameType, StackFrame, Value};
 
-use crate::{Runtime, VmError};
+use crate::{extend_environment, Runtime, VmError};
 
 use super::apply_builtin;
 
@@ -78,12 +76,12 @@ pub fn call(mut rt: Runtime, arity: usize) -> Result<Runtime> {
 
     let frame = StackFrame {
         frame_type: FrameType::CallFrame,
-        env: Rc::clone(&env),
+        env: env.clone(),
         address: Some(rt.current_thread.pc),
     };
 
     rt.current_thread.runtime_stack.push(frame);
-    rt.current_thread.extend_environment(prms, args)?;
+    rt = extend_environment(rt, prms, args)?;
     rt.current_thread.pc = addr;
 
     Ok(rt)
@@ -92,7 +90,7 @@ pub fn call(mut rt: Runtime, arity: usize) -> Result<Runtime> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytecode::{ByteCode, Environment, FnType};
+    use bytecode::{ByteCode, FnType};
 
     #[test]
     fn test_call() {
@@ -106,7 +104,7 @@ mod tests {
             sym: "Closure".to_string(),
             prms: vec![],
             addr: 123,
-            env: Environment::new_wrapped(),
+            env: Default::default(),
         });
 
         let result = call(rt, 0);

--- a/vm/ignite/src/micro_code/call.rs
+++ b/vm/ignite/src/micro_code/call.rs
@@ -81,7 +81,7 @@ pub fn call(mut rt: Runtime, arity: usize) -> Result<Runtime> {
     };
 
     rt.current_thread.runtime_stack.push(frame);
-    rt = extend_environment(rt, prms, args)?;
+    rt = extend_environment(rt, env.0, prms, args)?;
     rt.current_thread.pc = addr;
 
     Ok(rt)
@@ -93,7 +93,7 @@ mod tests {
     use bytecode::{ByteCode, FnType};
 
     #[test]
-    fn test_call() {
+    fn test_call() -> Result<()> {
         let rt = Runtime::new(vec![ByteCode::CALL(0), ByteCode::DONE]);
         let result = call(rt, 0);
         assert!(result.is_err());
@@ -107,9 +107,9 @@ mod tests {
             env: Default::default(),
         });
 
-        let result = call(rt, 0);
-        assert!(result.is_ok());
-        rt = result.unwrap();
+        let rt = call(rt, 0)?;
         assert_eq!(rt.current_thread.pc, 123);
+
+        Ok(())
     }
 }

--- a/vm/ignite/src/micro_code/enter_scope.rs
+++ b/vm/ignite/src/micro_code/enter_scope.rs
@@ -29,7 +29,8 @@ pub fn enter_scope(mut rt: Runtime, syms: Vec<Symbol>) -> Result<Runtime> {
         .map(|_| Value::Unitialized)
         .collect::<Vec<Value>>();
 
-    rt = extend_environment(rt, syms, uninitialized)?;
+    let current_env = rt.current_thread.env.clone();
+    rt = extend_environment(rt, current_env, syms, uninitialized)?;
 
     Ok(rt)
 }

--- a/vm/ignite/src/micro_code/exit_scope.rs
+++ b/vm/ignite/src/micro_code/exit_scope.rs
@@ -24,9 +24,7 @@ pub fn exit_scope(mut rt: Runtime) -> Result<Runtime> {
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
-
-    use bytecode::{Environment, FrameType, StackFrame, Value, W};
+    use bytecode::{weak_clone, Environment, FrameType, StackFrame, Value, W};
 
     use super::*;
 
@@ -35,11 +33,11 @@ mod tests {
         let mut rt = Runtime::new(vec![]);
         let env_a = Environment::new_wrapped();
         env_a.borrow_mut().set("a", 42);
-        let env_a_weak = Rc::downgrade(&env_a);
+        let env_a_weak = weak_clone(&env_a);
 
         let env_b = Environment::new_wrapped();
         env_b.borrow_mut().set("a", 123);
-        let env_b_weak = Rc::downgrade(&env_b);
+        let env_b_weak = weak_clone(&env_b);
 
         rt.current_thread
             .runtime_stack

--- a/vm/ignite/src/micro_code/exit_scope.rs
+++ b/vm/ignite/src/micro_code/exit_scope.rs
@@ -18,41 +18,57 @@ pub fn exit_scope(mut rt: Runtime) -> Result<Runtime> {
         .pop()
         .ok_or(VmError::RuntimeStackUnderflow)?;
 
-    rt.current_thread.env = prev_frame.env;
+    rt.current_thread.env = prev_frame.env.0;
     Ok(rt)
 }
 
 #[cfg(test)]
 mod tests {
-    use bytecode::{Environment, FrameType, StackFrame, Value};
+    use std::rc::Rc;
+
+    use bytecode::{Environment, FrameType, StackFrame, Value, W};
 
     use super::*;
 
     #[test]
-    fn test_exit_scope() {
+    fn test_exit_scope() -> Result<()> {
         let mut rt = Runtime::new(vec![]);
         let env_a = Environment::new_wrapped();
         env_a.borrow_mut().set("a", 42);
+        let env_a_weak = Rc::downgrade(&env_a);
 
         let env_b = Environment::new_wrapped();
         env_b.borrow_mut().set("a", 123);
+        let env_b_weak = Rc::downgrade(&env_b);
 
         rt.current_thread
             .runtime_stack
-            .push(StackFrame::new(FrameType::BlockFrame, env_a));
-        rt.current_thread.env = env_b;
+            .push(StackFrame::new(FrameType::BlockFrame, W(env_a_weak)));
+        rt.current_thread.env = env_b_weak;
 
         assert_eq!(
-            rt.current_thread.env.borrow().get(&"a".to_string()),
-            Some(Value::Int(123))
+            rt.current_thread
+                .env
+                .upgrade()
+                .unwrap()
+                .borrow()
+                .get(&"a".to_string())?,
+            Value::Int(123)
         );
 
         rt = exit_scope(rt).unwrap();
 
         assert_eq!(rt.current_thread.runtime_stack.len(), 0);
         assert_eq!(
-            rt.current_thread.env.borrow().get(&"a".to_string()),
-            Some(Value::Int(42))
+            rt.current_thread
+                .env
+                .upgrade()
+                .unwrap()
+                .borrow()
+                .get(&"a".to_string())?,
+            Value::Int(42)
         );
+
+        Ok(())
     }
 }

--- a/vm/ignite/src/micro_code/ld.rs
+++ b/vm/ignite/src/micro_code/ld.rs
@@ -29,9 +29,7 @@ pub fn ld(mut rt: Runtime, sym: Symbol) -> Result<Runtime> {
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
-
-    use bytecode::{Environment, Value};
+    use bytecode::{weak_clone, Environment, Value};
 
     use super::*;
 
@@ -51,11 +49,11 @@ mod tests {
     #[test]
     fn test_ld_with_parent() {
         let parent = Environment::new_wrapped();
-        let parent_weak = Rc::downgrade(&parent);
+        let parent_weak = weak_clone(&parent);
         parent.borrow_mut().set("x", 42);
         let mut rt = Runtime::new(vec![]);
         let env = Environment::new_wrapped();
-        let env_weak = Rc::downgrade(&env);
+        let env_weak = weak_clone(&env);
         env.borrow_mut().set_parent(parent_weak);
         rt.current_thread.env = env_weak;
         rt = ld(rt, "x".to_string()).unwrap();

--- a/vm/ignite/src/micro_code/ldf.rs
+++ b/vm/ignite/src/micro_code/ldf.rs
@@ -1,7 +1,5 @@
-use std::rc::Rc;
-
 use anyhow::Result;
-use bytecode::{FnType, Symbol, Value};
+use bytecode::{FnType, Symbol, Value, W};
 
 use crate::Runtime;
 
@@ -24,7 +22,7 @@ pub fn ldf(mut rt: Runtime, addr: usize, prms: Vec<Symbol>) -> Result<Runtime> {
         sym: "Closure".to_string(),
         prms,
         addr,
-        env: Rc::clone(&rt.current_thread.env),
+        env: W(rt.current_thread.env.clone()),
     };
 
     rt.current_thread.operand_stack.push(closure);
@@ -48,7 +46,7 @@ mod tests {
                 sym: "Closure".to_string(),
                 prms: vec!["y".to_string()],
                 addr: 0,
-                env: Rc::clone(&rt.current_thread.env),
+                env: W(rt.current_thread.env.clone()),
             }
         )
     }

--- a/vm/ignite/src/micro_code/post.rs
+++ b/vm/ignite/src/micro_code/post.rs
@@ -51,6 +51,7 @@ pub fn post(mut rt: Runtime) -> Result<Runtime> {
 #[cfg(test)]
 mod tests {
     use crate::{
+        extend_environment,
         micro_code::{ld, spawn, wait, yield_},
         MAIN_THREAD_ID,
     };
@@ -61,8 +62,7 @@ mod tests {
     fn test_post_01() -> Result<()> {
         let mut rt = Runtime::default();
         let sem = Semaphore::new(0);
-        rt.current_thread
-            .extend_environment(vec!["sem"], vec![sem.clone()])?;
+        rt = extend_environment(rt, vec!["sem"], vec![sem.clone()])?;
         rt = spawn(rt, 0)?; // spawn a child thread to populate ready queue
         rt = ld(rt, "sem".into())?;
         rt = post(rt)?;
@@ -79,8 +79,7 @@ mod tests {
     fn test_post_02() -> Result<()> {
         let mut rt = Runtime::default();
         let sem = Semaphore::new(0);
-        rt.current_thread
-            .extend_environment(vec!["sem"], vec![sem.clone()])?;
+        rt = extend_environment(rt, vec!["sem"], vec![sem.clone()])?;
         rt = spawn(rt, 0)?; // spawn a child thread to populate ready queue
         rt = yield_(rt)?; // yield the current thread to child thread
         rt = ld(rt, "sem".into())?;

--- a/vm/ignite/src/micro_code/post.rs
+++ b/vm/ignite/src/micro_code/post.rs
@@ -62,7 +62,8 @@ mod tests {
     fn test_post_01() -> Result<()> {
         let mut rt = Runtime::default();
         let sem = Semaphore::new(0);
-        rt = extend_environment(rt, vec!["sem"], vec![sem.clone()])?;
+        let current_env = rt.current_thread.env.clone();
+        rt = extend_environment(rt, current_env, vec!["sem"], vec![sem.clone()])?;
         rt = spawn(rt, 0)?; // spawn a child thread to populate ready queue
         rt = ld(rt, "sem".into())?;
         rt = post(rt)?;
@@ -79,7 +80,8 @@ mod tests {
     fn test_post_02() -> Result<()> {
         let mut rt = Runtime::default();
         let sem = Semaphore::new(0);
-        rt = extend_environment(rt, vec!["sem"], vec![sem.clone()])?;
+        let current_env = rt.current_thread.env.clone();
+        rt = extend_environment(rt, current_env, vec!["sem"], vec![sem.clone()])?;
         rt = spawn(rt, 0)?; // spawn a child thread to populate ready queue
         rt = yield_(rt)?; // yield the current thread to child thread
         rt = ld(rt, "sem".into())?;

--- a/vm/ignite/src/micro_code/reset.rs
+++ b/vm/ignite/src/micro_code/reset.rs
@@ -39,10 +39,8 @@ pub fn reset(mut rt: Runtime, ft: FrameType) -> Result<Runtime> {
 
 #[cfg(test)]
 mod tests {
-    use std::rc::Rc;
-
     use super::*;
-    use bytecode::{ByteCode, Environment, FrameType, StackFrame, Value, W};
+    use bytecode::{weak_clone, ByteCode, Environment, FrameType, StackFrame, Value, W};
 
     #[test]
     fn test_reset_restore_env() -> Result<()> {
@@ -51,9 +49,9 @@ mod tests {
         let env_a = Environment::new_wrapped();
         let env_b = Environment::new_wrapped();
         let env_c = Environment::new_wrapped();
-        let env_a_weak = W(Rc::downgrade(&env_a));
-        let env_b_weak = W(Rc::downgrade(&env_c));
-        let env_c_weak = W(Rc::downgrade(&env_b));
+        let env_a_weak = W(weak_clone(&env_a));
+        let env_b_weak = W(weak_clone(&env_c));
+        let env_c_weak = W(weak_clone(&env_b));
         env_c.borrow_mut().set("a", 42);
 
         let some_frame = StackFrame::new(FrameType::CallFrame, env_a_weak);
@@ -89,9 +87,9 @@ mod tests {
         let env_a = Environment::new_wrapped();
         let env_b = Environment::new_wrapped();
         let env_c = Environment::new_wrapped();
-        let env_a_weak = W(Rc::downgrade(&env_a));
-        let env_b_weak = W(Rc::downgrade(&env_c));
-        let env_c_weak = W(Rc::downgrade(&env_b));
+        let env_a_weak = W(weak_clone(&env_a));
+        let env_b_weak = W(weak_clone(&env_c));
+        let env_c_weak = W(weak_clone(&env_b));
         env_c.borrow_mut().set("a", 42);
 
         let some_frame = StackFrame::new(FrameType::CallFrame, env_a_weak);

--- a/vm/ignite/src/micro_code/wait.rs
+++ b/vm/ignite/src/micro_code/wait.rs
@@ -55,6 +55,7 @@ pub fn wait(mut rt: Runtime) -> Result<Runtime> {
 #[cfg(test)]
 mod tests {
     use crate::{
+        extend_environment,
         micro_code::{self, ld},
         MAIN_THREAD_ID,
     };
@@ -65,8 +66,7 @@ mod tests {
     fn test_wait_01() -> Result<()> {
         let mut rt = Runtime::default();
         let sem = Semaphore::new(1);
-        rt.current_thread
-            .extend_environment(vec!["sem"], vec![sem.clone()])?;
+        rt = extend_environment(rt, vec!["sem"], vec![sem.clone()])?;
         rt = micro_code::spawn(rt, 0)?; // spawn a child thread to populate ready queue
         rt = ld(rt, "sem".into())?;
         rt = wait(rt)?;
@@ -82,8 +82,7 @@ mod tests {
     fn test_wait_02() -> Result<()> {
         let mut rt = Runtime::default();
         let sem = Semaphore::new(0);
-        rt.current_thread
-            .extend_environment(vec!["sem"], vec![sem.clone()])?;
+        rt = extend_environment(rt, vec!["sem"], vec![sem.clone()])?;
         rt = micro_code::spawn(rt, 0)?; // spawn a child thread to populate ready queue
         rt = ld(rt, "sem".into())?;
         rt = wait(rt)?;

--- a/vm/ignite/src/micro_code/wait.rs
+++ b/vm/ignite/src/micro_code/wait.rs
@@ -66,7 +66,8 @@ mod tests {
     fn test_wait_01() -> Result<()> {
         let mut rt = Runtime::default();
         let sem = Semaphore::new(1);
-        rt = extend_environment(rt, vec!["sem"], vec![sem.clone()])?;
+        let current_env = rt.current_thread.env.clone();
+        rt = extend_environment(rt, current_env, vec!["sem"], vec![sem.clone()])?;
         rt = micro_code::spawn(rt, 0)?; // spawn a child thread to populate ready queue
         rt = ld(rt, "sem".into())?;
         rt = wait(rt)?;
@@ -82,7 +83,8 @@ mod tests {
     fn test_wait_02() -> Result<()> {
         let mut rt = Runtime::default();
         let sem = Semaphore::new(0);
-        rt = extend_environment(rt, vec!["sem"], vec![sem.clone()])?;
+        let current_env = rt.current_thread.env.clone();
+        rt = extend_environment(rt, current_env, vec!["sem"], vec![sem.clone()])?;
         rt = micro_code::spawn(rt, 0)?; // spawn a child thread to populate ready queue
         rt = ld(rt, "sem".into())?;
         rt = wait(rt)?;

--- a/vm/ignite/src/runtime/gc.rs
+++ b/vm/ignite/src/runtime/gc.rs
@@ -26,6 +26,10 @@ impl Runtime {
 }
 
 fn mark(rt: &Runtime) -> HashMap<EnvWeak, bool> {
+    if rt.debug {
+        println!("Mark begin")
+    }
+
     let mut marked = env_hashmap(rt);
 
     // Mark the current thread

--- a/vm/ignite/src/runtime/gc.rs
+++ b/vm/ignite/src/runtime/gc.rs
@@ -47,7 +47,13 @@ fn mark(rt: &Runtime) -> HashMap<EnvWeak, bool> {
 }
 
 fn sweep(mut rt: Runtime, m: HashMap<EnvWeak, bool>) -> Runtime {
-    todo!()
+    let registry = rt
+        .env_registry
+        .drain()
+        .filter(|env| *m.get(&W(weak_clone(env))).unwrap_or(&false))
+        .collect();
+    rt.env_registry = registry;
+    rt // Any environment that is not marked will be removed from the registry and dropped
 }
 
 fn env_hashmap(rt: &Runtime) -> HashMap<EnvWeak, bool> {

--- a/vm/ignite/src/runtime/gc.rs
+++ b/vm/ignite/src/runtime/gc.rs
@@ -1,0 +1,81 @@
+use std::{cell::RefCell, collections::HashMap, rc::Weak};
+
+use bytecode::{weak_clone, EnvWeak, Environment, StackFrame, Value, W};
+
+use crate::{Runtime, Thread};
+
+/// Runtime methods at runtime.
+impl Runtime {
+    /// Mark and sweep the environment registry.
+    /// This will remove all environments that are no longer referenced.
+    ///
+    /// - Mark environment x -> env_registry.get(x) = true
+    /// - Sweep environment x -> env_registry.remove(x) if env_registry.get(x) = false
+    /// - Clean up -> reset env_registry.get(x) = false
+    ///
+    /// Traverse through all the threads, for each thread:
+    ///   - Mark its current environment and the environment of closure values in the current environment,
+    ///     and the chain of parent environments.
+    ///   - Go through the runtime stack and mark all the environments and environment of closure values in
+    ///     their respective environment, and the chain of parent environments
+    ///   - Go through the operand stack and mark all the environments of closure values, and the chain of parent environments
+    pub fn mark_and_weep(self) -> Self {
+        let marked = mark(&self);
+        sweep(self, marked)
+    }
+}
+
+fn mark(rt: &Runtime) -> HashMap<EnvWeak, bool> {
+    let mut marked = env_hashmap(rt);
+
+    // Mark the current thread
+    marked = mark_thread(marked, &rt.current_thread);
+
+    // Mark the ready queue
+    for thread in rt.ready_queue.iter() {
+        marked = mark_thread(marked, thread);
+    }
+
+    // Mark the blocked queue
+    for (thread, _) in rt.blocked_queue.iter() {
+        marked = mark_thread(marked, thread);
+    }
+
+    // Zombie threads will be ignored
+
+    marked
+}
+
+fn sweep(mut rt: Runtime, m: HashMap<EnvWeak, bool>) -> Runtime {
+    todo!()
+}
+
+fn env_hashmap(rt: &Runtime) -> HashMap<EnvWeak, bool> {
+    let mut envs = HashMap::new();
+    for env in rt.env_registry.iter() {
+        envs.insert(W(weak_clone(env)), false);
+    }
+    envs
+}
+
+fn mark_thread(mut m: HashMap<EnvWeak, bool>, t: &Thread) -> HashMap<EnvWeak, bool> {
+    todo!()
+}
+
+fn mark_env(
+    mut m: HashMap<EnvWeak, bool>,
+    env: &Weak<RefCell<Environment>>,
+) -> HashMap<EnvWeak, bool> {
+    todo!()
+}
+
+fn mark_operand_stack(mut m: HashMap<EnvWeak, bool>, os: &Vec<Value>) -> HashMap<EnvWeak, bool> {
+    todo!()
+}
+
+fn mark_runtime_stack(
+    mut m: HashMap<EnvWeak, bool>,
+    rs: &Vec<StackFrame>,
+) -> HashMap<EnvWeak, bool> {
+    todo!()
+}

--- a/vm/ignite/src/runtime/mod.rs
+++ b/vm/ignite/src/runtime/mod.rs
@@ -1,0 +1,97 @@
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    time::{Duration, Instant},
+};
+
+use bytecode::{weak_clone, ByteCode, EnvStrong, Environment, Semaphore, ThreadID, W};
+
+use crate::Thread;
+
+pub use gc::*;
+pub use run::*;
+
+mod gc;
+mod run;
+
+pub const DEFAULT_TIME_QUANTUM: Duration = Duration::from_millis(100);
+pub const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(1);
+pub const MAIN_THREAD_ID: i64 = 1;
+
+/// The runtime of the virtual machine.
+/// It contains the instructions to execute, the current thread, and the ready and blocked threads.
+/// The instructions are the bytecode instructions to execute.
+/// The ready queue is a queue of threads that are ready to run.
+/// The blocked queue is a queue of threads that are waiting for some event to occur.
+/// The zombie threads are threads that have finished executing and are waiting to be joined.
+pub struct Runtime {
+    /// If the program is done.
+    pub done: bool,
+    /// If the program is in debug mode.
+    pub debug: bool,
+    /// The time the program started, used for calculating the time quantum.
+    pub time: Instant,
+    /// The maximum amount of time a thread can run before it is preempted.
+    pub time_quantum: Duration,
+    /// The interval at which to run the mark and sweep garbage collector.
+    pub gc_interval: Duration,
+    /// The instructions to execute.
+    pub instrs: Vec<ByteCode>,
+    /// The environment registry, holds strong references to environments.
+    pub env_registry: HashSet<EnvStrong>,
+    /// The number of threads that have been created.
+    pub thread_count: i64,
+    /// The current thread that is executing.
+    pub current_thread: Thread,
+    /// The threads that are ready to run.
+    pub ready_queue: VecDeque<Thread>,
+    /// The threads that are blocked.
+    pub blocked_queue: VecDeque<(Thread, Semaphore)>,
+    /// The threads that have finished executing, waiting to be joined.
+    pub zombie_threads: HashMap<ThreadID, Thread>,
+}
+
+/// Constructors for the runtime.
+impl Runtime {
+    pub fn new(instrs: Vec<ByteCode>) -> Self {
+        let global_env = Environment::new_global_wrapped();
+        let global_env_weak = weak_clone(&global_env);
+        let mut envs = HashSet::new();
+        envs.insert(W(global_env));
+
+        Runtime {
+            debug: false,
+            done: false,
+            time: Instant::now(),
+            time_quantum: DEFAULT_TIME_QUANTUM,
+            gc_interval: DEFAULT_GC_INTERVAL,
+            instrs,
+            env_registry: envs,
+            thread_count: 1,
+            current_thread: Thread::new(MAIN_THREAD_ID, global_env_weak),
+            ready_queue: VecDeque::new(),
+            blocked_queue: VecDeque::new(),
+            zombie_threads: HashMap::new(),
+        }
+    }
+}
+
+impl Default for Runtime {
+    fn default() -> Self {
+        Runtime::new(vec![])
+    }
+}
+
+/// Configuration for the runtime.
+impl Runtime {
+    pub fn set_time_quantum(&mut self, time_quantum: Duration) {
+        self.time_quantum = time_quantum;
+    }
+
+    pub fn set_gc_interval(&mut self, gc_interval: Duration) {
+        self.gc_interval = gc_interval;
+    }
+
+    pub fn set_debug_mode(&mut self) {
+        self.debug = true;
+    }
+}

--- a/vm/ignite/src/runtime/mod.rs
+++ b/vm/ignite/src/runtime/mod.rs
@@ -6,8 +6,6 @@ use std::{
 use bytecode::{weak_clone, ByteCode, EnvStrong, Environment, Semaphore, ThreadID, W};
 
 use crate::Thread;
-
-pub use gc::*;
 pub use run::*;
 
 mod gc;

--- a/vm/ignite/src/runtime/mod.rs
+++ b/vm/ignite/src/runtime/mod.rs
@@ -30,6 +30,8 @@ pub struct Runtime {
     pub time: Instant,
     /// The maximum amount of time a thread can run before it is preempted.
     pub time_quantum: Duration,
+    /// The time the garbage collector was last run.
+    pub gc_timer: Instant,
     /// The interval at which to run the mark and sweep garbage collector.
     pub gc_interval: Duration,
     /// The instructions to execute.
@@ -61,6 +63,7 @@ impl Runtime {
             done: false,
             time: Instant::now(),
             time_quantum: DEFAULT_TIME_QUANTUM,
+            gc_timer: Instant::now(),
             gc_interval: DEFAULT_GC_INTERVAL,
             instrs,
             env_registry: envs,

--- a/vm/ignite/src/runtime/run.rs
+++ b/vm/ignite/src/runtime/run.rs
@@ -33,12 +33,12 @@ impl Runtime {
     }
 
     pub fn should_garbage_collect(&self) -> bool {
-        self.time.elapsed() >= self.gc_interval
+        self.gc_timer.elapsed() >= self.gc_interval
     }
 
     pub fn garbage_collect(mut self) -> Self {
         self = self.mark_and_weep();
-        self.time = Instant::now();
+        self.gc_timer = Instant::now();
         self
     }
 

--- a/vm/ignite/src/runtime/run.rs
+++ b/vm/ignite/src/runtime/run.rs
@@ -52,6 +52,13 @@ impl Runtime {
         let pc = self.current_thread.pc;
         let instruction = self.instrs.get(pc).expect("PC out of bounds");
         println!("Thread: {}, PC: {}, {:?}", thread_id, pc, instruction);
+        println!("Operand Stack: {:?}", self.current_thread.operand_stack);
+        println!("Runtime Stack: {:?}", self.current_thread.runtime_stack);
+        println!(
+            "Environment: {:?}",
+            self.current_thread.env.upgrade().unwrap().borrow()
+        );
+        println!();
     }
 }
 

--- a/vm/ignite/src/runtime/run.rs
+++ b/vm/ignite/src/runtime/run.rs
@@ -1,95 +1,7 @@
-use std::{
-    collections::{HashMap, VecDeque},
-    time::{Duration, Instant},
-};
-
 use anyhow::Result;
-use bytecode::{weak_clone, ByteCode, EnvStrong, Environment, Semaphore, ThreadID, W};
+use bytecode::ByteCode;
 
-use crate::{micro_code, Thread, VmError};
-
-pub const DEFAULT_TIME_QUANTUM: Duration = Duration::from_millis(100);
-pub const DEFAULT_GC_INTERVAL: Duration = Duration::from_secs(1);
-pub const MAIN_THREAD_ID: i64 = 1;
-
-/// The runtime of the virtual machine.
-/// It contains the instructions to execute, the current thread, and the ready and blocked threads.
-/// The instructions are the bytecode instructions to execute.
-/// The ready queue is a queue of threads that are ready to run.
-/// The blocked queue is a queue of threads that are waiting for some event to occur.
-/// The zombie threads are threads that have finished executing and are waiting to be joined.
-pub struct Runtime {
-    /// If the program is done.
-    pub done: bool,
-    /// If the program is in debug mode.
-    pub debug: bool,
-    /// The time the program started, used for calculating the time quantum.
-    pub time: Instant,
-    /// The maximum amount of time a thread can run before it is preempted.
-    pub time_quantum: Duration,
-    /// The interval at which to run the mark and sweep garbage collector.
-    pub gc_interval: Duration,
-    /// The instructions to execute.
-    pub instrs: Vec<ByteCode>,
-    /// The environment registry, holds strong references to environments.
-    pub env_registry: HashMap<EnvStrong, bool>,
-    /// The number of threads that have been created.
-    pub thread_count: i64,
-    /// The current thread that is executing.
-    pub current_thread: Thread,
-    /// The threads that are ready to run.
-    pub ready_queue: VecDeque<Thread>,
-    /// The threads that are blocked.
-    pub blocked_queue: VecDeque<(Thread, Semaphore)>,
-    /// The threads that have finished executing, waiting to be joined.
-    pub zombie_threads: HashMap<ThreadID, Thread>,
-}
-
-/// Constructors for the runtime.
-impl Runtime {
-    pub fn new(instrs: Vec<ByteCode>) -> Self {
-        let global_env = Environment::new_global_wrapped();
-        let global_env_weak = weak_clone(&global_env);
-        let mut envs = HashMap::new();
-        envs.insert(W(global_env), false);
-
-        Runtime {
-            debug: false,
-            done: false,
-            time: Instant::now(),
-            time_quantum: DEFAULT_TIME_QUANTUM,
-            gc_interval: DEFAULT_GC_INTERVAL,
-            instrs,
-            env_registry: envs,
-            thread_count: 1,
-            current_thread: Thread::new(MAIN_THREAD_ID, global_env_weak),
-            ready_queue: VecDeque::new(),
-            blocked_queue: VecDeque::new(),
-            zombie_threads: HashMap::new(),
-        }
-    }
-}
-
-impl Default for Runtime {
-    fn default() -> Self {
-        Runtime::new(vec![])
-    }
-}
-
-/// Configuration for the runtime.
-impl Runtime {
-    pub fn set_time_quantum(&mut self, time_quantum: Duration) {
-        self.time_quantum = time_quantum;
-    }
-
-    pub fn set_gc_interval(&mut self, gc_interval: Duration) {
-        self.gc_interval = gc_interval;
-    }
-
-    pub fn set_debug_mode(&mut self) {
-        self.debug = true;
-    }
-}
+use crate::{micro_code, Runtime, VmError};
 
 /// Runtime methods at runtime.
 impl Runtime {
@@ -128,13 +40,6 @@ impl Runtime {
         let pc = self.current_thread.pc;
         let instruction = self.instrs.get(pc).expect("PC out of bounds");
         println!("Thread: {}, PC: {}, {:?}", thread_id, pc, instruction);
-    }
-
-    /// Mark and sweep the environment registry.
-    /// This will remove all environments that are no longer referenced.
-    ///
-    pub fn mark_and_weep(mut self) -> Self {
-        self
     }
 }
 
@@ -216,6 +121,10 @@ pub fn execute(rt: Runtime, instr: ByteCode) -> Result<Runtime> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use crate::MAIN_THREAD_ID;
+
     use super::*;
     use anyhow::{Ok, Result};
     use bytecode::{builtin, BinOp, ByteCode, FrameType, Symbol, UnOp, Value};

--- a/vm/ignite/src/thread.rs
+++ b/vm/ignite/src/thread.rs
@@ -65,7 +65,7 @@ where
     }
 
     rt.current_thread.env = weak_clone(&new_env);
-    rt.env_registry.insert(W(new_env), false);
+    rt.env_registry.insert(W(new_env));
 
     Ok(rt)
 }

--- a/vm/ignite/src/thread.rs
+++ b/vm/ignite/src/thread.rs
@@ -1,26 +1,29 @@
-use std::{cell::RefCell, rc::Rc};
+use std::{
+    cell::RefCell,
+    rc::{Rc, Weak},
+};
 
 use anyhow::Result;
-use bytecode::{Environment, StackFrame, Symbol, ThreadID, Value};
+use bytecode::{Environment, StackFrame, Symbol, ThreadID, Value, W};
 
-use crate::VmError;
+use crate::{Runtime, VmError};
 
 /// A thread of execution.
 /// Each thread has its own environment, operand stack, runtime stack, and program counter.
 #[derive(Debug, Default, Clone)]
 pub struct Thread {
     pub thread_id: ThreadID,
-    pub env: Rc<RefCell<Environment>>,
+    pub env: Weak<RefCell<Environment>>,
     pub operand_stack: Vec<Value>,
     pub runtime_stack: Vec<StackFrame>,
     pub pc: usize,
 }
 
 impl Thread {
-    pub fn new(thread_id: i64) -> Self {
+    pub fn new(thread_id: i64, env: Weak<RefCell<Environment>>) -> Self {
         Thread {
             thread_id,
-            env: Environment::new_global(),
+            env,
             operand_stack: Vec::new(),
             runtime_stack: Vec::new(),
             ..Default::default()
@@ -32,7 +35,7 @@ impl Thread {
     pub fn spawn_child(&self, thread_id: i64, pc: usize) -> Self {
         Thread {
             thread_id,
-            env: Rc::clone(&self.env),
+            env: Weak::clone(&self.env),
             operand_stack: Vec::new(),
             runtime_stack: Vec::new(),
             pc,
@@ -40,42 +43,34 @@ impl Thread {
     }
 }
 
-impl Thread {
-    /// Extend the current environment of the thread with new symbols and values.
-    ///
-    /// # Arguments
-    ///
-    /// * `syms` - The symbols to add to the environment.
-    ///
-    /// * `vals` - The values to add to the environment.
-    ///
-    /// # Errors
-    ///
-    /// If the symbols and values are not the same length.
-    pub fn extend_environment<S, V>(&mut self, syms: Vec<S>, vals: Vec<V>) -> Result<()>
-    where
-        S: Into<Symbol>,
-        V: Into<Value>,
-    {
-        if syms.len() != vals.len() {
-            return Err(VmError::IllegalArgument(
-                "symbols and values must be the same length".to_string(),
-            )
-            .into());
-        }
-
-        let current_env = Rc::clone(&self.env);
-        let new_env = Environment::new_wrapped();
-        new_env.borrow_mut().set_parent(current_env);
-
-        for (sym, val) in syms.into_iter().zip(vals.into_iter()) {
-            new_env.borrow_mut().set(sym, val);
-        }
-
-        self.env = new_env;
-
-        Ok(())
+pub fn extend_environment<S, V>(mut rt: Runtime, syms: Vec<S>, vals: Vec<V>) -> Result<Runtime>
+where
+    S: Into<Symbol>,
+    V: Into<Value>,
+{
+    if syms.len() != vals.len() {
+        return Err(VmError::IllegalArgument(
+            "symbols and values must be the same length".to_string(),
+        )
+        .into());
     }
+
+    let current_env = &rt
+        .current_thread
+        .env
+        .upgrade()
+        .ok_or(VmError::EnvironmentDroppedError)?;
+    let new_env = Environment::new_wrapped();
+    new_env.borrow_mut().set_parent(Rc::downgrade(current_env));
+
+    for (sym, val) in syms.into_iter().zip(vals.into_iter()) {
+        new_env.borrow_mut().set(sym, val);
+    }
+
+    rt.current_thread.env = Rc::downgrade(&new_env);
+    rt.env_registry.insert(W(new_env), false);
+
+    Ok(rt)
 }
 
 #[cfg(test)]
@@ -84,25 +79,94 @@ mod tests {
     use bytecode::Value;
 
     #[test]
-    fn test_extend_environment() -> Result<()> {
-        let mut t = Thread::new(1);
-        t.env.borrow_mut().set("a", 42);
-        t.env.borrow_mut().set("b", 123);
+    fn test_extend_environment_err() -> Result<()> {
+        let mut rt = Runtime::default();
+        let env = Environment::new_wrapped();
+        rt.current_thread.env = Rc::downgrade(&env);
+
+        rt.current_thread
+            .env
+            .upgrade()
+            .unwrap()
+            .borrow_mut()
+            .set("a", 42);
+        rt.current_thread
+            .env
+            .upgrade()
+            .unwrap()
+            .borrow_mut()
+            .set("b", 123);
 
         let empty: Vec<String> = Vec::new();
-        assert!(t.extend_environment(vec!["c", "d"], empty).is_err());
+        let result = extend_environment(rt, vec!["c", "d"], empty);
+        assert!(result.is_err());
 
-        t.extend_environment(vec!["c", "d"], vec![Value::Float(12.3), Value::Bool(true)])?;
+        Ok(())
+    }
 
-        assert_eq!(t.env.borrow().get(&"a".to_string()), Some(Value::Int(42)));
-        assert_eq!(t.env.borrow().get(&"b".to_string()), Some(Value::Int(123)));
+    #[test]
+    fn test_extend_environment() -> Result<()> {
+        let mut rt = Runtime::default();
+        let env = Environment::new_wrapped();
+        rt.current_thread.env = Rc::downgrade(&env);
+
+        rt.current_thread
+            .env
+            .upgrade()
+            .unwrap()
+            .borrow_mut()
+            .set("a", 42);
+        rt.current_thread
+            .env
+            .upgrade()
+            .unwrap()
+            .borrow_mut()
+            .set("b", 123);
+
+        let rt = extend_environment(
+            rt,
+            vec!["c", "d"],
+            vec![Value::Float(12.3), Value::Bool(true)],
+        )?;
+
         assert_eq!(
-            t.env.borrow().get(&"c".to_string()),
-            Some(Value::Float(12.3))
+            rt.current_thread
+                .env
+                .upgrade()
+                .unwrap()
+                .borrow()
+                .get(&"a".to_string())?,
+            Value::Int(42)
         );
+
         assert_eq!(
-            t.env.borrow().get(&"d".to_string()),
-            Some(Value::Bool(true))
+            rt.current_thread
+                .env
+                .upgrade()
+                .unwrap()
+                .borrow()
+                .get(&"b".to_string())?,
+            Value::Int(123)
+        );
+
+        assert_eq!(
+            rt.current_thread
+                .env
+                .upgrade()
+                .unwrap()
+                .borrow()
+                .get(&"c".to_string())?,
+            Value::Float(12.3)
+        );
+
+        assert_eq!(
+            rt.current_thread
+                .env
+                .upgrade()
+                .unwrap()
+                .borrow()
+                .get(&"d".to_string())?,
+            Value::Bool(true)
         );
 
         Ok(())


### PR DESCRIPTION
### Description
- [X] Refactor all references to `environments` by `thread`, `closures` and `runtime_stack` to weak references
- [X] Centralize ownership of environment to runtime
- [x] Mark and sweep environment
  - For 1 second (or other user defined time), there is going to be a round of mark and sweep:
  - Mark: Recursively mark all environments reachable from all non-zombie threads
  - Sweep: De-allocate any unmarked environments
  - Since only the runtime has ownership of the environments, we can de-allocate any environments that are unreachable by dropping them in the `Runtime` struct
- [X] Add support to anonymous functions

### Bug fixes
- Previously, extend_environment extends the current current at all times. This is not correct as for function calls, we want to extend the environment of the function. This PR corrects this behavior.

Resolves #47  