### PR TITLE
bug: call micro_code pop order

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,11 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo build --verbose
       - run: cargo test --verbose
+
+  build_script:
+    name: Rust project - build script
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: chmod +x build.sh
+      - run: ./build.sh

--- a/vm/ignite/src/micro_code/call.rs
+++ b/vm/ignite/src/micro_code/call.rs
@@ -30,6 +30,7 @@ use super::apply_builtin;
 /// If the closure is not of type closure or the arity of the closure does not match the number of arguments.
 pub fn call(mut rt: Runtime, arity: usize) -> Result<Runtime> {
     let mut args = Vec::new();
+    args.reserve_exact(arity);
 
     for _ in 0..arity {
         args.push(

--- a/vm/ignite/src/micro_code/call.rs
+++ b/vm/ignite/src/micro_code/call.rs
@@ -9,6 +9,8 @@ use super::apply_builtin;
 
 /// Call a function with the given number of arguments.
 /// First it pops n values from the operand stack where n is the arity of the function.
+/// The values will be the arguments to the function and they are pushed to a vector and reversed.
+/// i.e. the last argument is the top value of the operand stack.
 /// Then it pops the closure from the operand stack.
 /// It checks that the closure is a closure and that the arity of the closure matches the number of arguments.
 /// If the closure is a builtin function it applies the builtin function and returns.
@@ -37,6 +39,8 @@ pub fn call(mut rt: Runtime, arity: usize) -> Result<Runtime> {
                 .ok_or(VmError::OperandStackUnderflow)?,
         );
     }
+
+    args.reverse();
 
     let value = rt
         .current_thread


### PR DESCRIPTION
### Description
- At compile time, arguments to function call are pushed onto operand_stack using LDC in order.
- When running CALL, the popped values are in the reversed order. So CALL instruction need to  un-reverse the arguments

### Other changes
- Update CI/CD to run build script
