### PR TITLE
fix: update JOIN to consume PID on operand stack

### DIFF
--- a/vm/ignite/src/micro_code/join.rs
+++ b/vm/ignite/src/micro_code/join.rs
@@ -4,7 +4,7 @@ use crate::{Runtime, VmError};
 
 use super::yield_;
 
-/// Peeks the operand stack for the thread ID to join.
+/// Pop the operand stack for the thread ID to join.
 /// If the thread to join is in zombie state, then the current thread will be set to ready and the result
 /// of the zombie thread will be pushed onto the current thread's operand stack. The zombie thread is deallocated.
 /// If the thread to join is not found, then panic.
@@ -25,7 +25,7 @@ pub fn join(mut rt: Runtime) -> Result<Runtime> {
     let tid: i64 = rt
         .current_thread
         .operand_stack
-        .last()
+        .pop()
         .ok_or(VmError::OperandStackUnderflow)?
         .clone()
         .try_into()?;
@@ -33,6 +33,7 @@ pub fn join(mut rt: Runtime) -> Result<Runtime> {
     let Some(mut zombie_thread) = rt.zombie_threads.remove(&tid) else {
         // If the thread to join is not found, we need to yield control and try again
         rt.current_thread.pc -= 1; // Decrement the program counter to re-execute the join instruction
+        rt.current_thread.operand_stack.push(tid.into()); // Add the pid back to the operand stack
         let rt = yield_(rt)?;
         return Ok(rt);
     };
@@ -69,6 +70,13 @@ mod tests {
         // Add this point, both threads are in the ready state, so join should yield the current thread
         assert_eq!(rt.current_thread.thread_id, MAIN_THREAD_ID + 1);
 
+        // Add the parent thread ID to the operand stack of the child
+        rt = yield_(rt)?;
+        assert_eq!(rt.current_thread.thread_id, MAIN_THREAD_ID);
+
+        // PID should remain on the operand stack
+        assert_eq!(rt.current_thread.operand_stack.len(), 1);
+
         Ok(())
     }
 
@@ -91,6 +99,9 @@ mod tests {
             rt.current_thread.operand_stack.pop().unwrap(),
             Value::Int(0) // SPAWN adds 0 to the operand stack for the new thread
         );
+
+        // The PID of child should be popped off the operand stack
+        assert!(rt.current_thread.operand_stack.is_empty());
 
         Ok(())
     }


### PR DESCRIPTION
### Description
- Change JOIN instruction to consume PID on the operand stack after successfully executing past JOIN instruction